### PR TITLE
Add stub options to hypercore-archiver/swarm

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function Archiver (opts) {
   this.opts = opts
   mkdirp.sync(dir)
   this.ar = archiver(dir, opts)
-  this.swarm = swarm(this.ar)
+  this.swarm = swarm(this.ar, {})
 }
 
 Archiver.prototype.health = function (archive) {

--- a/index.js
+++ b/index.js
@@ -9,13 +9,13 @@ const swarm = require('hypercore-archiver/swarm')
 
 module.exports = Archiver
 
-function Archiver (opts) {
+function Archiver (opts, swarmOpts) {
   if (!(this instanceof Archiver)) return new Archiver(opts)
   var dir = opts.dir
   this.opts = opts
   mkdirp.sync(dir)
   this.ar = archiver(dir, opts)
-  this.swarm = swarm(this.ar, {})
+  this.swarm = swarm(this.ar, swarmOpts || {})
 }
 
 Archiver.prototype.health = function (archive) {


### PR DESCRIPTION
The swarm fails to start without an options parameter, even if it is empty.

PS: Thanks for making this! It's really useful :D